### PR TITLE
compile against 3.2 kernels

### DIFF
--- a/asus-switcheroo.c
+++ b/asus-switcheroo.c
@@ -11,6 +11,8 @@
  * the COPYING file in the top-level directory.
  */
 
+#include <linux/moduleparam.h>
+#include <linux/module.h>
 #include <linux/delay.h>
 #include <linux/pci.h>
 #include <linux/acpi.h>

--- a/byo-switcheroo.c
+++ b/byo-switcheroo.c
@@ -9,6 +9,8 @@
  * the COPYING file in the top-level directory.
  */
 
+#include <linux/moduleparam.h>
+#include <linux/module.h>
 #include <linux/delay.h>
 #include <linux/pci.h>
 #include <linux/acpi.h>

--- a/i915-jprobe.c
+++ b/i915-jprobe.c
@@ -10,6 +10,7 @@
  * the COPYING file in the top-level directory.
  */
 
+#include <linux/module.h>
 #include <linux/kprobes.h>
 #include <linux/kallsyms.h>
 #include <linux/notifier.h>

--- a/nouveau-jprobe.c
+++ b/nouveau-jprobe.c
@@ -10,6 +10,7 @@
  * the COPYING file in the top-level directory.
  */
 
+#include <linux/module.h>
 #include <linux/interrupt.h>
 #include <linux/kprobes.h>
 #include <linux/kallsyms.h>


### PR DESCRIPTION
added missing includes
_warning: not tested against older versions!_
